### PR TITLE
Complete crud itinerary plan

### DIFF
--- a/src/TraVinhMaps.Api/Controllers/EventAndFestivalController.cs
+++ b/src/TraVinhMaps.Api/Controllers/EventAndFestivalController.cs
@@ -50,11 +50,11 @@ public class EventAndFestivalController : ControllerBase
         {
             return this.ApiError("Object can't be null");
         }
-        if (createEventAndFestivalRequest.StartDate <= DateTime.Now)
+        if (createEventAndFestivalRequest.StartDate.Date <= DateTime.Now.Date)
         {
             return this.ApiError("StartDate must be after the current time");
         }
-        if (createEventAndFestivalRequest.EndDate <= createEventAndFestivalRequest.StartDate)
+        if (createEventAndFestivalRequest.EndDate.Date <= createEventAndFestivalRequest.StartDate.Date)
         {
             return this.ApiError("EndDate must be after StartDate");
         }

--- a/src/TraVinhMaps.Api/Controllers/ItineraryPlanController.cs
+++ b/src/TraVinhMaps.Api/Controllers/ItineraryPlanController.cs
@@ -1,0 +1,122 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using TraVinhMaps.Api.Extensions;
+using TraVinhMaps.Application.Common.Exceptions;
+using TraVinhMaps.Application.Features.ItineraryPlan.Interface;
+using TraVinhMaps.Application.Features.ItineraryPlan.Mappers;
+using TraVinhMaps.Application.Features.ItineraryPlan.Models;
+using TraVinhMaps.Domain.Entities;
+
+namespace TraVinhMaps.Api.Controllers;
+[Route("api/[controller]")]
+[ApiController]
+public class ItineraryPlanController : ControllerBase
+{
+    private readonly IItineraryPlanService _itineraryPlanService;
+
+    public ItineraryPlanController(IItineraryPlanService itineraryPlanService)
+    {
+        _itineraryPlanService = itineraryPlanService;
+    }
+
+    [HttpGet]
+    [Route("GetAllItineraryPlan")]
+    public async Task<IActionResult> GetAllItineraryPlan()
+    {
+        var listItineraryPlan = await this._itineraryPlanService.ListAllAsync();
+        return this.ApiOk(listItineraryPlan);
+    }
+
+    [HttpGet]
+    [Route("[action]/{id}", Name = "GetItineraryPlanById")]
+    public async Task<IActionResult> GetItineraryPlanById(string id)
+    {
+        var itineraryPlanDetail = await this._itineraryPlanService.GetByIdAsync(id);
+        return this.ApiOk(itineraryPlanDetail);
+    }
+
+    [HttpPost]
+    [Route("CreateItineraryPlan")]
+    public async Task<IActionResult> CreateItineraryPlan(ItineraryPlanRequest itineraryPlanRequest)
+    {
+        if(itineraryPlanRequest.Locations.Count< 2)
+        {
+            return this.ApiError("The itinerary must have at least 2 addresses.");
+        }
+        var itineraryPlan = ItineraryPlanMapper.Mapper.Map<ItineraryPlan>(itineraryPlanRequest);
+        var itineraryPlanCreated = await _itineraryPlanService.AddAsync(itineraryPlan);
+        return CreatedAtRoute("GetItineraryPlanById", new { id = itineraryPlanCreated.Id }, this.ApiOk(itineraryPlanCreated));
+    }
+
+    [HttpPut]
+    [Route("UpdateItineraryPlan")]
+    public async Task<IActionResult> UpdateItineraryPlan(UpdateItineraryPlanRequest updateItineraryPlanRequest)
+    {
+        if(updateItineraryPlanRequest == null)
+        {
+            return this.ApiError("Object can't be null");
+        }
+        var itineraryPlan = await _itineraryPlanService.GetByIdAsync(updateItineraryPlanRequest.Id);
+        if(itineraryPlan == null)
+        {
+            throw new NotFoundException("No itineraryPlan was found");
+        }
+        itineraryPlan.Name = updateItineraryPlanRequest.Name;
+        itineraryPlan.Duration = updateItineraryPlanRequest.Duration;
+        itineraryPlan.EstimatedCost = updateItineraryPlanRequest.EstimatedCost;
+        itineraryPlan.UpdateAt = DateTime.Now.ToLocalTime();
+        await this._itineraryPlanService.UpdateAsync(itineraryPlan);
+        return CreatedAtRoute("GetItineraryPlanById", new { id = itineraryPlan.Id }, this.ApiOk(itineraryPlan));
+    }
+
+    [HttpDelete]
+    [Route("DeleteItineraryPlan")]
+    public async Task<IActionResult> DeleteItineraryPlan(string id)
+    {
+        if (id == null)
+        {
+            return this.ApiError("id can't be null");
+        }
+        var itineraryPlan = await _itineraryPlanService.GetByIdAsync(id);
+        if (itineraryPlan == null)
+        {
+            throw new NotFoundException("No Destination was found");
+        }
+        if (itineraryPlan.Status == false)
+        {
+            return this.ApiError("Itinerary plan is already inactive");
+        }
+        itineraryPlan.Status = false;
+        itineraryPlan.UpdateAt = DateTime.Now.ToLocalTime();
+        await this._itineraryPlanService.UpdateAsync(itineraryPlan);
+        //return NoContent();
+        return this.ApiOk("Itinerary plan deleted successfully");
+    }
+
+    [HttpPut]
+    [Route("RestoreItineraryPlan/{id}")]
+    public async Task<IActionResult> RestoreItineraryPlan(string id)
+    {
+        if (id == null)
+        {
+            return this.ApiError("id can't be null");
+        }
+        var itineraryPlan = await _itineraryPlanService.GetByIdAsync(id);
+        if (itineraryPlan == null)
+        {
+            throw new NotFoundException("No Destination was found");
+        }
+        if (itineraryPlan.Status == true)
+        {
+            return this.ApiError("Itinerary plan is already inactive");
+        }
+        itineraryPlan.Status = true;
+        itineraryPlan.UpdateAt = DateTime.Now.ToLocalTime();
+        await this._itineraryPlanService.UpdateAsync(itineraryPlan);
+        //return NoContent();
+        return this.ApiOk("Itinerary plan restor successfully");
+    }
+}

--- a/src/TraVinhMaps.Api/TraVinhMaps.Api.sln
+++ b/src/TraVinhMaps.Api/TraVinhMaps.Api.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TraVinhMaps.Api", "TraVinhMaps.Api.csproj", "{0842ABEA-C175-6DB6-E472-0C03D354C461}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0842ABEA-C175-6DB6-E472-0C03D354C461}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0842ABEA-C175-6DB6-E472-0C03D354C461}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0842ABEA-C175-6DB6-E472-0C03D354C461}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0842ABEA-C175-6DB6-E472-0C03D354C461}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {89702A1B-97ED-40DE-B8FD-3AF23C8376D2}
+	EndGlobalSection
+EndGlobal

--- a/src/TraVinhMaps.Application/Features/ItineraryPlan/Interface/IItineraryPlanService.cs
+++ b/src/TraVinhMaps.Application/Features/ItineraryPlan/Interface/IItineraryPlanService.cs
@@ -1,0 +1,42 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using TraVinhMaps.Domain.Entities;
+
+namespace TraVinhMaps.Application.Features.ItineraryPlan.Interface;
+public interface IItineraryPlanService
+{
+    Task<TraVinhMaps.Domain.Entities.ItineraryPlan> GetByIdAsync(string id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<TraVinhMaps.Domain.Entities.ItineraryPlan>> ListAllAsync(CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Lists the asynchronous with the conditional
+    /// </summary>
+    /// <param name="predicate">The predicate is the conditional when you list (ex : a => a.id == 1)</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    Task<IEnumerable<TraVinhMaps.Domain.Entities.ItineraryPlan>> ListAsync(Expression<Func<TraVinhMaps.Domain.Entities.ItineraryPlan, bool>> predicate, CancellationToken cancellationToken = default);
+    Task<TraVinhMaps.Domain.Entities.ItineraryPlan> AddAsync(TraVinhMaps.Domain.Entities.ItineraryPlan entity, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Adds the range asynchronous with conditional
+    /// </summary>
+    /// <param name="entities">The entities.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    Task<IEnumerable<TraVinhMaps.Domain.Entities.ItineraryPlan>> AddRangeAsync(IEnumerable<TraVinhMaps.Domain.Entities.ItineraryPlan> entities, CancellationToken cancellationToken = default);
+    Task UpdateAsync(TraVinhMaps.Domain.Entities.ItineraryPlan entity, CancellationToken cancellationToken = default);
+    Task DeleteAsync(TraVinhMaps.Domain.Entities.ItineraryPlan entity, CancellationToken cancellationToken = default);
+    /// <summary>
+    /// Counts the asynchronous.
+    /// </summary>
+    /// <param name="predicate">The predicate.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns></returns>
+    Task<long> CountAsync(Expression<Func<TraVinhMaps.Domain.Entities.ItineraryPlan, bool>> predicate = null, CancellationToken cancellationToken = default);
+    Task<TraVinhMaps.Domain.Entities.ItineraryPlan> GetAsyns(Expression<Func<TraVinhMaps.Domain.Entities.ItineraryPlan, bool>> predicate, CancellationToken cancellationToken = default);
+}

--- a/src/TraVinhMaps.Application/Features/ItineraryPlan/ItineraryPlanService.cs
+++ b/src/TraVinhMaps.Application/Features/ItineraryPlan/ItineraryPlanService.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using TraVinhMaps.Application.Features.ItineraryPlan.Interface;
+using TraVinhMaps.Application.UnitOfWorks;
+
+namespace TraVinhMaps.Application.Features.ItineraryPlan;
+public class ItineraryPlanService : IItineraryPlanService
+{
+    private readonly IItineraryPlanRepository _repository;
+
+    public ItineraryPlanService(IItineraryPlanRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Domain.Entities.ItineraryPlan> AddAsync(Domain.Entities.ItineraryPlan entity, CancellationToken cancellationToken = default)
+    {
+        return await _repository.AddAsync(entity, cancellationToken);
+    }
+
+    public async Task<IEnumerable<Domain.Entities.ItineraryPlan>> AddRangeAsync(IEnumerable<Domain.Entities.ItineraryPlan> entities, CancellationToken cancellationToken = default)
+    {
+        return await _repository.AddRangeAsync(entities, cancellationToken);
+    }
+
+    public async Task<long> CountAsync(Expression<Func<Domain.Entities.ItineraryPlan, bool>> predicate = null, CancellationToken cancellationToken = default)
+    {
+        return await _repository.CountAsync(predicate, cancellationToken);
+    }
+
+    public Task DeleteAsync(Domain.Entities.ItineraryPlan entity, CancellationToken cancellationToken = default)
+    {
+        return _repository.DeleteAsync(entity, cancellationToken);
+    }
+
+    public async Task<Domain.Entities.ItineraryPlan> GetAsyns(Expression<Func<Domain.Entities.ItineraryPlan, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        return await _repository.GetAsyns(predicate, cancellationToken);
+    }
+
+    public async Task<Domain.Entities.ItineraryPlan> GetByIdAsync(string id, CancellationToken cancellationToken = default)
+    {
+        return await _repository.GetByIdAsync(id, cancellationToken);
+    }
+
+    public async Task<IEnumerable<Domain.Entities.ItineraryPlan>> ListAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _repository.ListAllAsync(cancellationToken);
+    }
+
+    public async Task<IEnumerable<Domain.Entities.ItineraryPlan>> ListAsync(Expression<Func<Domain.Entities.ItineraryPlan, bool>> predicate, CancellationToken cancellationToken = default)
+    {
+        return await _repository.ListAsync(predicate, cancellationToken);
+    }
+
+    public Task UpdateAsync(Domain.Entities.ItineraryPlan entity, CancellationToken cancellationToken = default)
+    {
+        return _repository.UpdateAsync(entity, cancellationToken);
+    }
+}

--- a/src/TraVinhMaps.Application/Features/ItineraryPlan/Mappers/ItineraryPlanMapper.cs
+++ b/src/TraVinhMaps.Application/Features/ItineraryPlan/Mappers/ItineraryPlanMapper.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoMapper;
+
+namespace TraVinhMaps.Application.Features.ItineraryPlan.Mappers;
+public static class ItineraryPlanMapper
+{
+    private static readonly Lazy<IMapper> lazy = new Lazy<IMapper>(() =>
+    {
+        var config = new MapperConfiguration(cfg =>
+        {
+            cfg.ShouldMapProperty = p => p.GetMethod.IsPublic || p.GetMethod.IsAssembly;
+            cfg.AddProfile<ItineraryPlanMappingProfile>();
+        });
+        var mapper = config.CreateMapper();
+        return mapper;
+    });
+
+    public static IMapper Mapper => lazy.Value;
+}

--- a/src/TraVinhMaps.Application/Features/ItineraryPlan/Mappers/ItineraryPlanMappingProfile.cs
+++ b/src/TraVinhMaps.Application/Features/ItineraryPlan/Mappers/ItineraryPlanMappingProfile.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoMapper;
+using TraVinhMaps.Application.Features.ItineraryPlan.Models;
+using TraVinhMaps.Domain.Entities;
+
+namespace TraVinhMaps.Application.Features.ItineraryPlan.Mappers;
+public class ItineraryPlanMappingProfile : AutoMapper.Profile
+{
+    public ItineraryPlanMappingProfile()
+    {
+        CreateMap<ItineraryPlanRequest, TraVinhMaps.Domain.Entities.ItineraryPlan>();
+    }
+}

--- a/src/TraVinhMaps.Application/Features/ItineraryPlan/Models/ItineraryPlanRequest.cs
+++ b/src/TraVinhMaps.Application/Features/ItineraryPlan/Models/ItineraryPlanRequest.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace TraVinhMaps.Application.Features.ItineraryPlan.Models;
+public class ItineraryPlanRequest
+{
+    public required string Name { get; set; }
+    public string? Duration { get; set; }
+    public HashSet<string>? Locations { get; set; }
+    public string? EstimatedCost { get; set; }
+}

--- a/src/TraVinhMaps.Application/Features/ItineraryPlan/Models/UpdateItineraryPlanRequest.cs
+++ b/src/TraVinhMaps.Application/Features/ItineraryPlan/Models/UpdateItineraryPlanRequest.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace TraVinhMaps.Application.Features.ItineraryPlan.Models;
+public class UpdateItineraryPlanRequest
+{
+    public required string Id { get; set; }
+    public required string Name { get; set; }
+    public string? Duration { get; set; }
+    public string? EstimatedCost { get; set; }
+}

--- a/src/TraVinhMaps.Application/UnitOfWorks/IItineraryPlanRepository.cs
+++ b/src/TraVinhMaps.Application/UnitOfWorks/IItineraryPlanRepository.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TraVinhMaps.Domain.Entities;
+
+namespace TraVinhMaps.Application.UnitOfWorks;
+public interface IItineraryPlanRepository : IRepository<ItineraryPlan>
+{
+}

--- a/src/TraVinhMaps.Domain/Entities/ItineraryPlan.cs
+++ b/src/TraVinhMaps.Domain/Entities/ItineraryPlan.cs
@@ -36,27 +36,6 @@ public class ItineraryPlan : BaseEntity
     /// </value>
     [BsonElement("locations")]
     public List<string>? Locations { get; set; }
-
-    /// <summary>
-    /// Gets or sets the start date of the itinerary plan.
-    /// </summary>
-    /// <value>
-    /// The start date.
-    /// </value>
-    [BsonElement("startDate")]
-    [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
-    public required DateTime StartDate { get; set; }
-
-    /// <summary>
-    /// Gets or sets the end date of the itinerary plan.
-    /// </summary>
-    /// <value>
-    /// The end date.
-    /// </value>
-    [BsonElement("endDate")]
-    [BsonDateTimeOptions(Kind = DateTimeKind.Utc)]
-    public required DateTime EndDate { get; set; }
-
     /// <summary>
     /// Gets or sets the estimated cost of the itinerary plan.
     /// </summary>
@@ -73,7 +52,7 @@ public class ItineraryPlan : BaseEntity
     ///   <c>true</c> if status is active; otherwise, <c>false</c>.
     /// </value>
     [BsonElement("status")]
-    public required bool Status { get; set; }
+    public required bool Status { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the update date.

--- a/src/TraVinhMaps.Infrastructure/CustomRepositories/ItineraryPlanRepository.cs
+++ b/src/TraVinhMaps.Infrastructure/CustomRepositories/ItineraryPlanRepository.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TraVinhMaps.Application.UnitOfWorks;
+using TraVinhMaps.Domain.Entities;
+using TraVinhMaps.Infrastructure.Db;
+using TraVinhMaps.Infrastructure.UnitOfWork;
+
+namespace TraVinhMaps.Infrastructure.CustomRepositories
+{
+    public class ItineraryPlanRepository : Repository<ItineraryPlan>, IItineraryPlanRepository
+    {
+        public ItineraryPlanRepository(IDbContext context) : base(context)
+        {
+        }
+    }
+}

--- a/src/TraVinhMaps.Infrastructure/DependencyInjection.cs
+++ b/src/TraVinhMaps.Infrastructure/DependencyInjection.cs
@@ -13,6 +13,8 @@ using TraVinhMaps.Application.Features.Destination;
 using TraVinhMaps.Application.Features.Destination.Interface;
 using TraVinhMaps.Application.Features.EventAndFestivalFeature;
 using TraVinhMaps.Application.Features.EventAndFestivalFeature.Interface;
+using TraVinhMaps.Application.Features.ItineraryPlan;
+using TraVinhMaps.Application.Features.ItineraryPlan.Interface;
 using TraVinhMaps.Application.Features.Notifications;
 using TraVinhMaps.Application.Features.Notifications.Interface;
 using TraVinhMaps.Application.Features.OcopProduct;
@@ -84,6 +86,10 @@ public static class DependencyInjection
         // Role Management
         services.AddScoped<IRoleRepository, RoleRepository>();
         services.AddScoped<IRoleService, RoleService>();
+
+        // Itinerary Plan Management
+        services.AddScoped<IItineraryPlanRepository, ItineraryPlanRepository>();
+        services.AddScoped<IItineraryPlanService, ItineraryPlanService>();
 
         // Tags
         services.AddScoped<ITagService, TagService>();


### PR DESCRIPTION
feat: ItineraryPlan API with CRUD

- Added GetAllItineraryPlan and GetItineraryPlanById endpoints to fetch itinerary plans
- Implemented CreateItineraryPlan with minimum location validation (>= 2)
- Added UpdateItineraryPlan endpoint with data updating and null-check handling
- Implemented soft delete functionality in DeleteItineraryPlan (status flag)
- Added RestoreItineraryPlan endpoint to reactivate a soft-deleted itinerary
- Used custom ApiOk and ApiError response wrappers for consistent API responses fix: Create event and festival
- Modìied start date and end date