### PR TITLE
Add Firebase push notification support

### DIFF
--- a/src/TraVinhMaps.Api/Program.cs
+++ b/src/TraVinhMaps.Api/Program.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using FirebaseAdmin;
+using Google.Apis.Auth.OAuth2;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -187,6 +189,15 @@ builder.Services.Configure<KestrelServerOptions>(options =>
 {
     options.Limits.MaxRequestBodySize = 104857600; // 100MB
 });
+
+// config for push notifications using Firebase
+if (FirebaseApp.DefaultInstance == null)
+{
+    FirebaseApp.Create(new AppOptions()
+    {
+        Credential = GoogleCredential.FromFile("travinhmap-329cf-firebase-adminsdk-fbsvc-c5af50e9a3.json"),
+    });
+}
 
 var app = builder.Build();
 

--- a/src/TraVinhMaps.Api/TraVinhMaps.Api.csproj
+++ b/src/TraVinhMaps.Api/TraVinhMaps.Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/TraVinhMaps.Application/Features/Notifications/FirebaseNotificationService.cs
+++ b/src/TraVinhMaps.Application/Features/Notifications/FirebaseNotificationService.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TraVinhMaps.Application.Features.Notifications.Interface;
+using TraVinhMaps.Application.Features.Notifications.Models;
+using FirebaseAdmin;
+using FirebaseAdmin.Messaging;
+using Google.Apis.Auth.OAuth2;
+
+namespace TraVinhMaps.Application.Features.Notifications;
+public class FirebaseNotificationService : IFirebaseNotificationService
+{
+    public async Task<string> PushNotificationAsync(NotificationRequest notificationRequest, string topic = "all")
+    {
+        var message = new Message()
+        {
+            Topic = topic,
+            Notification = new FirebaseAdmin.Messaging.Notification()
+            {
+                Title = notificationRequest.IconCode.StartsWith("fa-")
+            ? $"<i class='fas {notificationRequest.IconCode}'></i> {notificationRequest.Title}"
+            : $"{GetEmojiFromCode(notificationRequest.IconCode)} {notificationRequest.Title ?? string.Empty}",
+                Body = notificationRequest.Content,
+            },
+            Android = new AndroidConfig()
+            {
+                Notification = new AndroidNotification()
+                {
+                    ChannelId = "HIGH_PRIORITY_NOTIFICATION"
+                }
+            },
+            Data = new Dictionary<string, string>()
+        {
+            { "route", "/notification" },
+            { "event_time", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString() } // tránh lỗi parse timestamp
+        }
+        };
+        return await FirebaseMessaging.DefaultInstance.SendAsync(message);
+    }
+
+    private string GetEmojiFromCode(string code)
+    {
+        return code switch
+        {
+            "bun" => "\uD83C\uDF5C", // Emoji bat bun
+            "moon" => "\uD83C\uDF1D", // Emoji the moon 
+            "heart" => "\u2764\uFE0F", // Emoji the heart
+            "sparkles" => "\u2728", // Emoji the star
+            _ => "\uD83C\uDF5C" // Default  bat bun
+        };
+    }
+}

--- a/src/TraVinhMaps.Application/Features/Notifications/Interface/IFirebaseNotificationService.cs
+++ b/src/TraVinhMaps.Application/Features/Notifications/Interface/IFirebaseNotificationService.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TraVinhMaps.Application.Features.Notifications.Models;
+
+namespace TraVinhMaps.Application.Features.Notifications.Interface;
+public interface IFirebaseNotificationService
+{
+    Task<string> PushNotificationAsync(NotificationRequest notificationRequest, string topic = "all");
+}

--- a/src/TraVinhMaps.Application/Features/Notifications/Interface/INotificationService.cs
+++ b/src/TraVinhMaps.Application/Features/Notifications/Interface/INotificationService.cs
@@ -31,4 +31,6 @@ public interface INotificationService
     /// <returns>Task indicating success.</returns>
     Task<bool> SendNotificationAsync(NotificationRequest notificationRequest, CancellationToken cancellation = default);
     Task<IEnumerable<Notification>> GetUniqueNotificationsAsync(CancellationToken cancellationToken = default);
+    Task<IEnumerable<Notification>> GetRecentNotificationsAsync(CancellationToken cancellationToken = default);
+
 }

--- a/src/TraVinhMaps.Application/Features/Notifications/NotificationsService.cs
+++ b/src/TraVinhMaps.Application/Features/Notifications/NotificationsService.cs
@@ -79,4 +79,13 @@ public class NotificationsService : INotificationService
     {
         return await _notificationsRepository.GetUniqueNotificationsAsync(cancellationToken);
     }
+
+    public async Task<IEnumerable<Notification>> GetRecentNotificationsAsync(CancellationToken cancellationToken = default)
+    {
+        var notifications = await _notificationsRepository.ListAllAsync(cancellationToken);
+        return notifications
+       .OrderByDescending(n => n.CreatedAt)
+       .Take(20)
+       .ToList();
+    }
 }

--- a/src/TraVinhMaps.Application/TraVinhMaps.Application.csproj
+++ b/src/TraVinhMaps.Application/TraVinhMaps.Application.csproj
@@ -15,8 +15,10 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="CloudinaryDotNet" Version="1.27.5" />
+    <PackageReference Include="FirebaseAdmin" Version="3.2.0" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.70.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />

--- a/src/TraVinhMaps.Infrastructure/DependencyInjection.cs
+++ b/src/TraVinhMaps.Infrastructure/DependencyInjection.cs
@@ -90,6 +90,7 @@ public static class DependencyInjection
         // Notification
         services.AddScoped<INotificationsRepository, NotificationsRepository>();
         services.AddScoped<INotificationService, NotificationsService>();
+        services.AddScoped<IFirebaseNotificationService, FirebaseNotificationService>();
 
         // Admin Management
         services.AddScoped<IAdminRepository, AdminsRepository>();


### PR DESCRIPTION
Integrated Firebase Admin SDK to enable push notifications. Added FirebaseNotificationService and its interface, updated NotificationsController to send notifications via Firebase, and registered the new service in dependency injection. Introduced a new endpoint to fetch recent notifications and updated dependencies to include FirebaseAdmin and Google.Apis.Auth.