### PR TITLE
Refactor InteractionLogs to use service and auto-assign UserId

### DIFF
--- a/src/TraVinhMaps.Api/Controllers/InteractionLogsController.cs
+++ b/src/TraVinhMaps.Api/Controllers/InteractionLogsController.cs
@@ -7,6 +7,7 @@ using TraVinhMaps.Api.Extensions;
 using TraVinhMaps.Application.Common.Exceptions;
 using TraVinhMaps.Application.Features.Interaction.Mappers;
 using TraVinhMaps.Application.Features.Interaction.Models;
+using TraVinhMaps.Application.Features.InteractionLogs.Interface;
 using TraVinhMaps.Application.Features.InteractionLogs.Mappers;
 using TraVinhMaps.Application.Features.InteractionLogs.Models;
 using TraVinhMaps.Application.UnitOfWorks;
@@ -17,45 +18,45 @@ namespace TraVinhMaps.Api.Controllers;
 [ApiController]
 public class InteractionLogsController : ControllerBase
 {
-    private readonly IBaseRepository<Domain.Entities.InteractionLogs> _repository;
-    public InteractionLogsController(IBaseRepository<Domain.Entities.InteractionLogs> repository)
+    private readonly IInteractionLogsService _interactionLogsService;
+    public InteractionLogsController(IInteractionLogsService interactionLogsService)
     {
-        _repository = repository;
+        _interactionLogsService = interactionLogsService;
     }
     [HttpGet]
     [Route("GetAllInteractionLogs")]
     public async Task<IActionResult> GetAllInteractionLogs()
     {
-        var listInteractionLogs = await _repository.ListAllAsync();
+        var listInteractionLogs = await _interactionLogsService.ListAllAsync();
         return this.ApiOk(listInteractionLogs);
     }
     [HttpGet]
     [Route("GetInteractionLogsById/{id}", Name = "GetInteractionLogsById")]
     public async Task<IActionResult> GetInteractionLogsById(string id)
     {
-        var interactionLogs = await _repository.GetByIdAsync(id);
+        var interactionLogs = await _interactionLogsService.GetByIdAsync(id);
         return this.ApiOk(interactionLogs);
     }
     [HttpGet]
     [Route("CountInteractionLogs")]
     public async Task<IActionResult> CountInteractionLogs()
     {
-        var countInteractionLogs = await _repository.CountAsync();
+        var countInteractionLogs = await _interactionLogsService.CountAsync();
         return this.ApiOk(countInteractionLogs);
     }
     [HttpPost]
     [Route("AddInteractionLogs")]
-    public async Task<IActionResult> AddInteractionLogs([FromForm] CreateInteractionLogsRequest createInteractionLogsRequest)
+    public async Task<IActionResult> AddInteractionLogs([FromBody] CreateInteractionLogsRequest createInteractionLogsRequest)
     {
-        var createInteractionLogs = InteractionLogsMapper.Mapper.Map<InteractionLogs>(createInteractionLogsRequest);
-        var interactionLogs = await _repository.AddAsync(createInteractionLogs);
+        //var createInteractionLogs = InteractionLogsMapper.Mapper.Map<InteractionLogs>(createInteractionLogsRequest);
+        var interactionLogs = await _interactionLogsService.AddAsync(createInteractionLogsRequest);
         return CreatedAtRoute("GetInteractionLogsById", new { id = interactionLogs.Id }, this.ApiOk(interactionLogs));
     }
     [HttpPut]
     [Route("UpdateInteractionLogs")]
     public async Task<IActionResult> UpdateInteractionLogs([FromBody] UpdateInteractionLogsRequest updateInteractionLogsRequest)
     {
-        var existingInteractionLogs = await _repository.GetByIdAsync(updateInteractionLogsRequest.Id);
+        var existingInteractionLogs = await _interactionLogsService.GetByIdAsync(updateInteractionLogsRequest.Id);
         if (existingInteractionLogs == null)
         {
             throw new NotFoundException("InteractionLogs not found.");
@@ -65,19 +66,19 @@ public class InteractionLogsController : ControllerBase
         existingInteractionLogs.ItemId = updateInteractionLogsRequest.ItemId;
         existingInteractionLogs.ItemType = updateInteractionLogsRequest.ItemType;
         existingInteractionLogs.Duration = updateInteractionLogsRequest.Duration;
-        await _repository.UpdateAsync(existingInteractionLogs);
+        await _interactionLogsService.UpdateAsync(existingInteractionLogs);
         return this.ApiOk("InteractionLogs updated successfully.");
     }
     [HttpDelete]
     [Route("DeleteInteractionLogs/{id}")]
     public async Task<IActionResult> DeleteInteractionLogs(string id)
     {
-        var interactionLogs = await _repository.GetByIdAsync(id);
+        var interactionLogs = await _interactionLogsService.GetByIdAsync(id);
         if (interactionLogs == null)
         {
             throw new NotFoundException("InteractionLogs not found.");
         }
-        await _repository.DeleteAsync(interactionLogs);
+        await _interactionLogsService.DeleteAsync(interactionLogs);
         return this.ApiOk("InteractionLogs deleted successfully.");
     }
 }

--- a/src/TraVinhMaps.Application/Features/InteractionLogs/InteractionLogsService.cs
+++ b/src/TraVinhMaps.Application/Features/InteractionLogs/InteractionLogsService.cs
@@ -5,23 +5,43 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using TraVinhMaps.Application.Features.InteractionLogs.Interface;
+using TraVinhMaps.Application.Features.InteractionLogs.Mappers;
+using TraVinhMaps.Application.Features.InteractionLogs.Models;
+using TraVinhMaps.Application.Features.Users.Interface;
 using TraVinhMaps.Application.UnitOfWorks;
 
 namespace TraVinhMaps.Application.Features.InteractionLogs;
 public class InteractionLogsService : IInteractionLogsService
 {
     private readonly IBaseRepository<Domain.Entities.InteractionLogs> _repository;
-    public InteractionLogsService(IBaseRepository<Domain.Entities.InteractionLogs> repository)
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private readonly IUserService _userService;
+    public InteractionLogsService(IBaseRepository<Domain.Entities.InteractionLogs> repository, IHttpContextAccessor httpContextAccessor, IUserService userService)
     {
         _repository = repository;
+        _httpContextAccessor = httpContextAccessor;
+        _userService = userService;
     }
 
-    public Task<Domain.Entities.InteractionLogs> AddAsync(Domain.Entities.InteractionLogs entity, CancellationToken cancellationToken = default)
+    public Task<Domain.Entities.InteractionLogs> AddAsync(CreateInteractionLogsRequest entity, CancellationToken cancellationToken = default)
     {
-        return _repository.AddAsync(entity, cancellationToken);
+        if (entity == null)
+            throw new ArgumentNullException(nameof(entity));
+
+        // Lấy userId từ ClaimsPrincipal (được gán bởi SessionAuthenticationHandler) qua IHttpContextAccessor
+        var userId = _httpContextAccessor.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (string.IsNullOrEmpty(userId))
+            throw new UnauthorizedAccessException("User not authenticated.");
+
+        var createInteractionLogs = InteractionLogsMapper.Mapper.Map<Domain.Entities.InteractionLogs>(entity);
+        createInteractionLogs.UserId = userId;
+
+        return _repository.AddAsync(createInteractionLogs, cancellationToken);
     }
 
     public Task<long> CountAsync(Expression<Func<Domain.Entities.InteractionLogs, bool>> predicate = null, CancellationToken cancellationToken = default)

--- a/src/TraVinhMaps.Application/Features/InteractionLogs/Interface/IInteractionLogsService.cs
+++ b/src/TraVinhMaps.Application/Features/InteractionLogs/Interface/IInteractionLogsService.cs
@@ -7,13 +7,14 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
+using TraVinhMaps.Application.Features.InteractionLogs.Models;
 
 namespace TraVinhMaps.Application.Features.InteractionLogs.Interface;
 public interface IInteractionLogsService
 {
     Task<Domain.Entities.InteractionLogs> GetByIdAsync(string id, CancellationToken cancellationToken = default);
     Task<IEnumerable<Domain.Entities.InteractionLogs>> ListAllAsync(CancellationToken cancellationToken = default);
-    Task<Domain.Entities.InteractionLogs> AddAsync(Domain.Entities.InteractionLogs entity, CancellationToken cancellationToken = default);
+    Task<Domain.Entities.InteractionLogs> AddAsync(CreateInteractionLogsRequest entity, CancellationToken cancellationToken = default);
     Task UpdateAsync(Domain.Entities.InteractionLogs entity, CancellationToken cancellationToken = default);
     Task DeleteAsync(Domain.Entities.InteractionLogs entity, CancellationToken cancellationToken = default);
     Task<long> CountAsync(Expression<Func<Domain.Entities.InteractionLogs, bool>> predicate = null, CancellationToken cancellationToken = default);

--- a/src/TraVinhMaps.Application/Features/InteractionLogs/Models/CreateInteractionLogsRequest.cs
+++ b/src/TraVinhMaps.Application/Features/InteractionLogs/Models/CreateInteractionLogsRequest.cs
@@ -11,7 +11,6 @@ using MongoDB.Bson.Serialization.Attributes;
 namespace TraVinhMaps.Application.Features.InteractionLogs.Models;
 public class CreateInteractionLogsRequest
 {
-    public required string UserId { get; set; }
     public required string ItemId { get; set; }
     public string? ItemType { get; set; }
     public int? Duration { get; set; }


### PR DESCRIPTION
Updated InteractionLogsController to use IInteractionLogsService instead of repository directly. The AddAsync method now accepts CreateInteractionLogsRequest and automatically assigns the UserId from the authenticated user, removing the need to provide UserId in the request. Updated interface and model accordingly.