### PR TITLE
Add homepage data aggregation and top events/products APIs

### DIFF
--- a/src/TraVinhMaps.Api/Controllers/EventAndFestivalController.cs
+++ b/src/TraVinhMaps.Api/Controllers/EventAndFestivalController.cs
@@ -207,4 +207,12 @@ public class EventAndFestivalController : ControllerBase
         return this.ApiOk("Event and festival restored successfully");
     }
 
+    [HttpGet]
+    [Route("GetTopEvents")]
+    public async Task<IActionResult> GetTopEvents()
+    {
+        var events = await _eventAndFestivalService.GetTopUpcomingEvents();
+        return this.ApiOk(events);
+    }
+
 }

--- a/src/TraVinhMaps.Api/Controllers/HomeController.cs
+++ b/src/TraVinhMaps.Api/Controllers/HomeController.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using TraVinhMaps.Api.Extensions;
+using TraVinhMaps.Application.Features.Destination.Interface;
+using TraVinhMaps.Application.Features.EventAndFestivalFeature.Interface;
+using TraVinhMaps.Application.Features.OcopProduct.Interface;
+
+namespace TraVinhMaps.Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class HomeController : ControllerBase
+{
+    private readonly ITouristDestinationService _touristDestinationService;
+    private readonly IEventAndFestivalService _eventAndFestivalService;
+    private readonly IOcopProductService _ocopProductService;
+
+    public HomeController(
+        ITouristDestinationService touristDestinationService,
+        IEventAndFestivalService eventAndFestivalService,
+        IOcopProductService ocopProductService
+        )
+    {
+        _touristDestinationService = touristDestinationService;
+        _eventAndFestivalService = eventAndFestivalService;
+        _ocopProductService = ocopProductService;
+    }
+
+    [HttpGet]
+    [Route("GetDataHomePage")]
+    public async Task<IActionResult> GetDataHomePage()
+    {
+        // Gọi song song cho nhanh (tối ưu), hoặc tuần tự nếu cần
+        var favoriteDestinationsTask = _touristDestinationService.GetTop10FavoriteDestination();
+        var topEventsTask = _eventAndFestivalService.GetTopUpcomingEvents();
+        var ocopProductsTask = _ocopProductService.GetCurrentOcopProduct();
+
+        await Task.WhenAll(favoriteDestinationsTask, topEventsTask, ocopProductsTask);
+
+        var result = new
+        {
+            FavoriteDestinations = favoriteDestinationsTask.Result,
+            TopEvents = topEventsTask.Result,
+            OcopProducts = ocopProductsTask.Result
+        };
+
+        return this.ApiOk(result);
+    }
+}

--- a/src/TraVinhMaps.Api/Controllers/OcopProductController.cs
+++ b/src/TraVinhMaps.Api/Controllers/OcopProductController.cs
@@ -448,4 +448,16 @@ public class OcopProductController : ControllerBase
     {
         return this.ApiOk(await _service.GetOcopProductsByIds(listId));
     }
+
+    [HttpGet]
+    [Route("GetCurrentOcopProduct")]
+    public async Task<IActionResult> GetCurrentOcopProduct()
+    {
+        var ocopProducts = await _service.GetCurrentOcopProduct();
+        if (ocopProducts == null || !ocopProducts.Any())
+        {
+            return this.ApiError("No current OCOP products found.");
+        }
+        return this.ApiOk(ocopProducts);
+    }
 }

--- a/src/TraVinhMaps.Application/Features/EventAndFestivalFeature/EventAndFestivalService.cs
+++ b/src/TraVinhMaps.Application/Features/EventAndFestivalFeature/EventAndFestivalService.cs
@@ -61,6 +61,14 @@ public class EventAndFestivalService : IEventAndFestivalService
         return await _repository.GetByIdAsync(id, cancellationToken);
     }
 
+    public async Task<IEnumerable<EventAndFestival>> GetTopUpcomingEvents(CancellationToken cancellationToken = default)
+    {
+        var allEvents = await _repository.ListAllAsync(cancellationToken);
+        return allEvents
+       .OrderByDescending(e => e.StartDate)
+       .Take(3);
+    }
+
     public async Task<IEnumerable<EventAndFestival>> ListAllAsync(CancellationToken cancellationToken = default)
     {
         return await _repository.ListAllAsync(cancellationToken);

--- a/src/TraVinhMaps.Application/Features/EventAndFestivalFeature/Interface/IEventAndFestivalService.cs
+++ b/src/TraVinhMaps.Application/Features/EventAndFestivalFeature/Interface/IEventAndFestivalService.cs
@@ -41,4 +41,5 @@ public interface IEventAndFestivalService
     Task<EventAndFestival> GetAsyns(Expression<Func<EventAndFestival, bool>> predicate, CancellationToken cancellationToken = default);
     Task<string> AddEventAndFestivalImage(string id, string imageUrl, CancellationToken cancellationToken = default);
     Task<string> DeleteEventAndFestivalImage(string id, string imageUrl, CancellationToken cancellationToken = default);
+    Task<IEnumerable<EventAndFestival>> GetTopUpcomingEvents(CancellationToken cancellationToken = default);
 }

--- a/src/TraVinhMaps.Application/Features/OcopProduct/Interface/IOcopProductService.cs
+++ b/src/TraVinhMaps.Application/Features/OcopProduct/Interface/IOcopProductService.cs
@@ -36,5 +36,6 @@ public interface IOcopProductService
     // OCOP Product Comparison
     Task<IEnumerable<OcopProductAnalytics>> CompareProductsAsync(IEnumerable<string> productIds, string timeRange = "month", DateTime? startDate = null, DateTime? endDate = null, CancellationToken cancellationToken = default);
     Task<IEnumerable<Domain.Entities.OcopProduct>> GetOcopProductsByIds(List<string> idList, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Domain.Entities.OcopProduct>> GetCurrentOcopProduct(CancellationToken cancellationToken = default);
 
 }

--- a/src/TraVinhMaps.Application/Features/OcopProduct/OcopProductService.cs
+++ b/src/TraVinhMaps.Application/Features/OcopProduct/OcopProductService.cs
@@ -190,4 +190,13 @@ public class OcopProductService : IOcopProductService
     {
         return await _ocopProductRepository.GetOcopProductsByIds(idList, cancellationToken);
     }
+
+    public async Task<IEnumerable<Domain.Entities.OcopProduct>> GetCurrentOcopProduct(CancellationToken cancellationToken = default)
+    {
+        var ocops = await _ocopProductRepository.ListAllAsync(cancellationToken);
+        return ocops
+        .OrderByDescending(p => p.OcopYearRelease)
+        .Take(10);
+
+    }
 }


### PR DESCRIPTION
Introduces HomeController with an endpoint to aggregate top favorite destinations, upcoming events, and current OCOP products for the homepage. Adds new endpoints in EventAndFestivalController and OcopProductController to fetch top upcoming events and current OCOP products, respectively. Updates service interfaces and implementations to support these new data retrieval methods.