### PR TITLE
Add endpoint to fetch latest reviews

### DIFF
--- a/src/TraVinhMaps.Api/Controllers/ReviewController.cs
+++ b/src/TraVinhMaps.Api/Controllers/ReviewController.cs
@@ -74,6 +74,13 @@ public class ReviewController : ControllerBase
         var countReviews = await _reviewService.CountAsync();
         return this.ApiOk(countReviews);
     }
+    [HttpGet]
+    [Route("GetLatestReviews")]
+    public async Task<IActionResult> GetLatestReviews()
+    {
+        var listLatestReview = await _reviewService.GetLatestReviewsAsync();
+        return this.ApiOk(listLatestReview);
+    }
     [Authorize]
     [HttpPost("AddReview")]
     [Consumes("multipart/form-data")]

--- a/src/TraVinhMaps.Application/Features/Review/Interface/IReviewService.cs
+++ b/src/TraVinhMaps.Application/Features/Review/Interface/IReviewService.cs
@@ -15,6 +15,7 @@ public interface IReviewService
 {
     Task<Domain.Entities.Review> GetByIdAsync(string id, CancellationToken cancellationToken = default);
     Task<ReviewResponse> GetReviewByIdAsync(string id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<ReviewResponse>> GetLatestReviewsAsync(int count = 5, CancellationToken cancellationToken = default);
     Task<IEnumerable<ReviewResponse>> FilterReviewsAsync(string? destinationId, int? rating, DateTime? startAt, DateTime? endAt, CancellationToken cancellationToken = default);
     Task<IEnumerable<ReviewResponse>> ListAllAsync(CancellationToken cancellationToken = default);
     Task<Domain.Entities.Review> AddAsync(CreateReviewRequest createReviewRequest, List<string> imageUrl, CancellationToken cancellationToken = default);

--- a/src/TraVinhMaps.Application/Repositories/IReviewRepository.cs
+++ b/src/TraVinhMaps.Application/Repositories/IReviewRepository.cs
@@ -14,6 +14,7 @@ namespace TraVinhMaps.Application.Repositories;
 public interface IReviewRepository : IBaseRepository<Review>
 {
     Task<ReviewResponse> GetReviewByIdAsync(string id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<ReviewResponse>> GetLatestReviewsAsync(int count = 5, CancellationToken cancellationToken = default);
     Task<IEnumerable<ReviewResponse>> FilterReviewsAsync(string? destinationId, int? rating, DateTime? startAt, DateTime? endAt, CancellationToken cancellationToken = default);
     Task<String> AddImageReview(string id, string imageUrl, CancellationToken cancellationToken = default);
     Task<Reply> AddReply(string id, Reply reply, CancellationToken cancellationToken = default);

--- a/src/TraVinhMaps.Infrastructure/Repositories/ReviewRepository.cs
+++ b/src/TraVinhMaps.Infrastructure/Repositories/ReviewRepository.cs
@@ -6,12 +6,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DnsClient;
+using System.Xml.Linq;
 using MongoDB.Driver;
 using TraVinhMaps.Application.Features.Review.Models;
 using TraVinhMaps.Application.Repositories;
 using TraVinhMaps.Domain.Entities;
 using TraVinhMaps.Infrastructure.CustomRepositories;
 using TraVinhMaps.Infrastructure.Db;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace TraVinhMaps.Infrastructure.Repositories;
 public class ReviewRepository : BaseRepository<Review>, IReviewRepository
@@ -116,5 +119,22 @@ public class ReviewRepository : BaseRepository<Review>, IReviewRepository
         };
 
         return response;
+    }
+
+    public async Task<IEnumerable<ReviewResponse>> GetLatestReviewsAsync(int count = 5, CancellationToken cancellationToken = default)
+    {
+        var reviews = await _collection.Find(Builders<Review>.Filter.Empty).SortByDescending(r => r.CreatedAt).Limit(count).ToListAsync(cancellationToken);
+        var responses = reviews.Select(r => new ReviewResponse
+        {
+            Id = r.Id,
+            Rating = r.Rating,
+            Images = r.Images,
+            Comment = r.Comment,
+            UserId = r.UserId,
+            DestinationId = r.DestinationId,
+            CreatedAt = r.CreatedAt,
+            Reply = r.Reply
+        });
+        return responses;
     }
 }


### PR DESCRIPTION
Introduced a new API endpoint GetLatestReviews in ReviewController to retrieve the most recent reviews. Added GetLatestReviewsAsync methods to IReviewService and IReviewRepository interfaces, and implemented them in ReviewService and ReviewRepository. This allows clients to fetch a configurable number of the latest reviews, including user and destination details.