### PR TITLE
Add duplicate checks and repository methods for entities

### DIFF
--- a/src/TraVinhMaps.Api/Controllers/CompanyController.cs
+++ b/src/TraVinhMaps.Api/Controllers/CompanyController.cs
@@ -8,6 +8,7 @@ using TraVinhMaps.Application.Common.Exceptions;
 using TraVinhMaps.Application.Features.Company.Interface;
 using TraVinhMaps.Application.Features.Company.Mappers;
 using TraVinhMaps.Application.Features.Company.Models;
+using TraVinhMaps.Application.Features.OcopType.Models;
 using TraVinhMaps.Application.UnitOfWorks;
 using TraVinhMaps.Domain.Entities;
 
@@ -46,6 +47,11 @@ public class CompanyController : ControllerBase
     [Route("AddCompany")]
     public async Task<IActionResult> AddCompany([FromBody] CreateCompanyRequest createCompanyRequest)
     {
+        var allCompany = await _companyService.ListAllAsync();
+        if (allCompany != null && allCompany.Any(c => c.Name == createCompanyRequest.Name))
+        {
+            return this.ApiError("Company already exists.");
+        }
         var createCompany = CompanyMapper.Mapper.Map<Company>(createCompanyRequest);
         var company = await _companyService.AddAsync(createCompany);
         return CreatedAtRoute("GetCompanyById", new { id = company.Id }, this.ApiOk(company));
@@ -58,6 +64,11 @@ public class CompanyController : ControllerBase
         if (existingCompany == null)
         {
             throw new NotFoundException("Company not found.");
+        }
+        var allCompany = await _companyService.ListAllAsync();
+        if (allCompany != null && allCompany.Any(c => c.Name == updateCompanyRequest.Name && c.Id != updateCompanyRequest.Id))
+        {
+            return this.ApiError("Company already exists.");
         }
 
         existingCompany.Name = updateCompanyRequest.Name;

--- a/src/TraVinhMaps.Api/Controllers/OcopTypeController.cs
+++ b/src/TraVinhMaps.Api/Controllers/OcopTypeController.cs
@@ -4,11 +4,9 @@
 using Microsoft.AspNetCore.Mvc;
 using TraVinhMaps.Api.Extensions;
 using TraVinhMaps.Application.Common.Exceptions;
-using TraVinhMaps.Application.Features.OcopProduct.Models;
 using TraVinhMaps.Application.Features.OcopType.Interface;
 using TraVinhMaps.Application.Features.OcopType.Mappers;
 using TraVinhMaps.Application.Features.OcopType.Models;
-using TraVinhMaps.Application.Repositories;
 using TraVinhMaps.Application.UnitOfWorks;
 using TraVinhMaps.Domain.Entities;
 
@@ -47,10 +45,10 @@ public class OcopTypeController : ControllerBase
     [Route("AddOcopType")]
     public async Task<IActionResult> AddOcopType([FromBody] CreateOcopTypeRequest createOcopTypeRequest)
     {
-        var exitingOcopType = await _typeService.GetOcopTypeByName(createOcopTypeRequest.OcopTypeName);
-        if (exitingOcopType != null)
+        var allOcopTypes = await _typeService.ListAllAsync();
+        if (allOcopTypes != null && allOcopTypes.Any(ot => ot.OcopTypeName == createOcopTypeRequest.OcopTypeName))
         {
-            return this.ApiError("Ocop type name already exists.");
+            return this.ApiError("Ocop type already exists.");
         }
         var createOcopType = OcopTypeMapper.Mapper.Map<OcopType>(createOcopTypeRequest);
         createOcopType.OcopTypeStatus = true;
@@ -66,7 +64,11 @@ public class OcopTypeController : ControllerBase
         {
             throw new NotFoundException("Ocop type not found.");
         }
-
+        var allOcopTypes = await _typeService.ListAllAsync();
+        if (allOcopTypes != null && allOcopTypes.Any(ot => ot.OcopTypeName == updateOcopTypeRequest.OcopTypeName && ot.Id != updateOcopTypeRequest.Id))
+        {
+            return this.ApiError("Ocop type already exists.");
+        }
         existingOcopType.OcopTypeName = updateOcopTypeRequest.OcopTypeName;
 
         if (updateOcopTypeRequest.UpdateAt.HasValue)

--- a/src/TraVinhMaps.Api/Controllers/SellingLinkController.cs
+++ b/src/TraVinhMaps.Api/Controllers/SellingLinkController.cs
@@ -53,7 +53,7 @@ public class SellingLinkController : ControllerBase
     public async Task<IActionResult> AddSellingLink([FromBody] CreateSellingLinkRequest createSellingLinkRequest)
     {
         var exitingLink = await _service.GetSellingLinkByProductId(createSellingLinkRequest.ProductId);
-        if(exitingLink != null && exitingLink.Any(l => l.Link == createSellingLinkRequest.Link))
+        if(exitingLink != null && exitingLink.Any(l => l.Link == createSellingLinkRequest.Link && l.Title == createSellingLinkRequest.Title))
         {
             return this.ApiError("This link already exists with this ocop product.");
         }
@@ -69,6 +69,11 @@ public class SellingLinkController : ControllerBase
         if (existingSellingLink == null)
         {
             throw new NotFoundException("Selling link not found.");
+        }
+        var exitingLink = await _service.GetSellingLinkByProductId(updateSellingLinkRequest.ProductId);
+        if (exitingLink != null && exitingLink.Any(l => l.Link == updateSellingLinkRequest.Link && l.Title == updateSellingLinkRequest.Title))
+        {
+            return this.ApiError("This link already exists with this ocop product.");
         }
         existingSellingLink.ProductId = updateSellingLinkRequest.ProductId;
         existingSellingLink.Title = updateSellingLinkRequest.Title;

--- a/src/TraVinhMaps.Application/Features/Company/CompanyService.cs
+++ b/src/TraVinhMaps.Application/Features/Company/CompanyService.cs
@@ -8,15 +8,18 @@ using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
 using TraVinhMaps.Application.Features.Company.Interface;
+using TraVinhMaps.Application.Repositories;
 using TraVinhMaps.Application.UnitOfWorks;
 
 namespace TraVinhMaps.Application.Features.Company;
 public class CompanyService : ICompanyService
 {
     private readonly IBaseRepository<Domain.Entities.Company> _repository;
-    public CompanyService(IBaseRepository<Domain.Entities.Company> repository)
+    private readonly ICompanyRepository _companyRepository;
+    public CompanyService(IBaseRepository<Domain.Entities.Company> repository, ICompanyRepository companyRepository)
     {
         _repository = repository;
+        _companyRepository = companyRepository;
     }
 
     public Task<Domain.Entities.Company> AddAsync(Domain.Entities.Company entity, CancellationToken cancellationToken = default)
@@ -32,6 +35,11 @@ public class CompanyService : ICompanyService
     public Task<Domain.Entities.Company> GetByIdAsync(string id, CancellationToken cancellationToken = default)
     {
         return _repository.GetByIdAsync(id, cancellationToken);
+    }
+
+    public Task<Domain.Entities.Company> GetCompanyByName(string name, CancellationToken cancellationToken = default)
+    {
+        return _companyRepository.GetCompanyByName(name, cancellationToken);
     }
 
     public Task<IEnumerable<Domain.Entities.Company>> ListAllAsync(CancellationToken cancellationToken = default)

--- a/src/TraVinhMaps.Application/Features/Company/Interface/ICompanyService.cs
+++ b/src/TraVinhMaps.Application/Features/Company/Interface/ICompanyService.cs
@@ -12,6 +12,7 @@ namespace TraVinhMaps.Application.Features.Company.Interface;
 public interface ICompanyService
 {
     Task<Domain.Entities.Company> GetByIdAsync(string id, CancellationToken cancellationToken = default);
+    Task<Domain.Entities.Company> GetCompanyByName(string name, CancellationToken cancellationToken = default);
     Task<IEnumerable<Domain.Entities.Company>> ListAllAsync(CancellationToken cancellationToken = default);
     Task<Domain.Entities.Company> AddAsync(Domain.Entities.Company entity, CancellationToken cancellationToken = default);
     Task UpdateAsync(Domain.Entities.Company entity, CancellationToken cancellationToken = default);

--- a/src/TraVinhMaps.Application/Features/OcopProduct/Interface/IOcopProductService.cs
+++ b/src/TraVinhMaps.Application/Features/OcopProduct/Interface/IOcopProductService.cs
@@ -19,6 +19,7 @@ public interface IOcopProductService
     Task<bool> RestoreOcopProductAsync(string id, CancellationToken cancellationToken = default);
     Task<long> CountAsync(Expression<Func<Domain.Entities.OcopProduct, bool>> predicate = null, CancellationToken cancellationToken = default);
     Task<Domain.Entities.OcopProduct> GetOcopProductByName(string name, CancellationToken cancellationToken = default);
+    Task<Domain.Entities.SellLocation> GetSellLocationByName(string id, string name, CancellationToken cancellationToken = default);
     Task<IEnumerable<Domain.Entities.OcopProduct>> GetOcopProductByOcopTypeId(string ocopTypeId, CancellationToken cancellationToken = default);
     Task<IEnumerable<Domain.Entities.OcopProduct>> GetOcopProductByCompanyId(string companyId, CancellationToken cancellationToken = default);
     Task<String> AddImageOcopProduct(string id, string imageUrl, CancellationToken cancellationToken = default);

--- a/src/TraVinhMaps.Application/Features/OcopProduct/OcopProductService.cs
+++ b/src/TraVinhMaps.Application/Features/OcopProduct/OcopProductService.cs
@@ -199,4 +199,9 @@ public class OcopProductService : IOcopProductService
         .Take(10);
 
     }
+
+    public Task<SellLocation> GetSellLocationByName(string id, string name, CancellationToken cancellationToken = default)
+    {
+        return _ocopProductRepository.GetSellLocationByName(id, name, cancellationToken);
+    }
 }

--- a/src/TraVinhMaps.Application/Features/SellingLink/Models/CreateSellingLinkRequest.cs
+++ b/src/TraVinhMaps.Application/Features/SellingLink/Models/CreateSellingLinkRequest.cs
@@ -6,5 +6,5 @@ public class CreateSellingLinkRequest
 {
     public required string ProductId { get; set; }
     public required string Title { get; set; }
-    public required string Link { get; set; }
+    public string? Link { get; set; }
 }

--- a/src/TraVinhMaps.Application/Features/SellingLink/Models/UpdateSellingLinkRequest.cs
+++ b/src/TraVinhMaps.Application/Features/SellingLink/Models/UpdateSellingLinkRequest.cs
@@ -7,6 +7,6 @@ public class UpdateSellingLinkRequest
     public required string Id { get; set; }
     public required string ProductId { get; set; }
     public required string Title { get; set; }
-    public required string Link { get; set; }
+    public string Link { get; set; }
     public DateTime? UpdateAt { get; set; } = DateTime.UtcNow;
 }

--- a/src/TraVinhMaps.Application/Repositories/ICompanyRepository.cs
+++ b/src/TraVinhMaps.Application/Repositories/ICompanyRepository.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TraVinhMaps.Application.UnitOfWorks;
+using TraVinhMaps.Domain.Entities;
+
+namespace TraVinhMaps.Application.Repositories;
+public interface ICompanyRepository : IBaseRepository<Company>
+{
+    Task<Company> GetCompanyByName(string name, CancellationToken cancellationToken = default);
+}

--- a/src/TraVinhMaps.Application/Repositories/IOcopProductRepository.cs
+++ b/src/TraVinhMaps.Application/Repositories/IOcopProductRepository.cs
@@ -8,6 +8,7 @@ namespace TraVinhMaps.Application.UnitOfWorks;
 public interface IOcopProductRepository : IBaseRepository<OcopProduct>
 {
     Task<OcopProduct> GetOcopProductByName(string name, CancellationToken cancellationToken = default);
+    Task<Domain.Entities.SellLocation> GetSellLocationByName(string id, string name, CancellationToken cancellationToken = default);
     Task<IEnumerable<OcopProduct>> GetOcopProductByCompanyId(string companyId, CancellationToken cancellationToken = default);
     Task<IEnumerable<OcopProduct>> GetOcopProductByOcopTypeId(string ocopTypeId, CancellationToken cancellationToken = default);
     Task<SellLocation> AddSellLocation(string id, SellLocation sellLocation, CancellationToken cancellationToken = default);

--- a/src/TraVinhMaps.Domain/Entities/SellingLink.cs
+++ b/src/TraVinhMaps.Domain/Entities/SellingLink.cs
@@ -29,7 +29,7 @@ public class SellingLink : BaseEntity
     /// The link.
     /// </value>
     [BsonElement("link")]
-    public required string Link { get; set; }
+    public string Link { get; set; }
     /// <summary>
     /// Gets or sets the update at.
     /// </summary>

--- a/src/TraVinhMaps.Infrastructure/DependencyInjection.cs
+++ b/src/TraVinhMaps.Infrastructure/DependencyInjection.cs
@@ -104,6 +104,7 @@ public static class DependencyInjection
 
         //Company
         services.AddScoped<ICompanyService, CompanyService>();
+        services.AddScoped<ICompanyRepository, CompanyRepository>();
 
         //Review
         services.AddScoped<IReviewRepository, ReviewRepository>();

--- a/src/TraVinhMaps.Infrastructure/Repositories/CompanyRepository.cs
+++ b/src/TraVinhMaps.Infrastructure/Repositories/CompanyRepository.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using MongoDB.Driver;
+using TraVinhMaps.Application.Repositories;
+using TraVinhMaps.Domain.Entities;
+using TraVinhMaps.Infrastructure.CustomRepositories;
+using TraVinhMaps.Infrastructure.Db;
+
+namespace TraVinhMaps.Infrastructure.Repositories;
+public class CompanyRepository : BaseRepository<Company>, ICompanyRepository
+{
+    public CompanyRepository(IDbContext dbContext) : base(dbContext)
+    {
+
+    }
+    public async Task<Company> GetCompanyByName(string name, CancellationToken cancellationToken = default)
+    {
+        var filter = Builders<Company>.Filter.Eq(c => c.Name, name);
+        return await _collection.Find(filter).FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/src/TraVinhMaps.Infrastructure/Repositories/OcopProductRepository.cs
+++ b/src/TraVinhMaps.Infrastructure/Repositories/OcopProductRepository.cs
@@ -621,4 +621,15 @@ public class OcopProductRepository : BaseRepository<OcopProduct>, IOcopProductRe
         var ocops = await _collection.Find(filter).ToListAsync(cancellationToken);
         return ocops;
     }
+
+    public async Task<SellLocation> GetSellLocationByName(string id, string name, CancellationToken cancellationToken = default)
+    {
+        var filter = Builders<OcopProduct>.Filter.Eq(o => o.Id, id);
+        var ocopProduct = await _collection.Find(filter).FirstOrDefaultAsync(cancellationToken);
+        if (ocopProduct == null) return null;
+        if (ocopProduct.Sellocations == null || !ocopProduct.Sellocations.Any())
+            return null;
+        var sellLocation = ocopProduct.Sellocations.FirstOrDefault(s => s.LocationName != null && s.LocationName.Equals(name, StringComparison.OrdinalIgnoreCase));
+        return sellLocation;
+    }
 }


### PR DESCRIPTION
Implemented duplicate name checks for Company, OcopProduct, OcopType, and SellingLink entities in their respective controllers. Added repository interfaces and methods for fetching by name, including ICompanyRepository and IOcopProductRepository. Updated service constructors and dependency injection to support new repositories. Changed SellingLink 'Link' property to be nullable in models and entity.