### PR TITLE
Add image deletion for OCOP products

### DIFF
--- a/src/TraVinhMaps.Api/Controllers/OcopProductController.cs
+++ b/src/TraVinhMaps.Api/Controllers/OcopProductController.cs
@@ -9,6 +9,7 @@ using TraVinhMaps.Api.Hubs;
 using TraVinhMaps.Application.Common.Exceptions;
 using TraVinhMaps.Application.External;
 using TraVinhMaps.Application.Features.Company.Interface;
+using TraVinhMaps.Application.Features.Destination.Models;
 using TraVinhMaps.Application.Features.Markers.Interface;
 using TraVinhMaps.Application.Features.OcopProduct;
 using TraVinhMaps.Application.Features.OcopProduct.Interface;
@@ -170,7 +171,7 @@ public class OcopProductController : ControllerBase
     }
     [HttpPost]
     [Route("AddImageOcopProduct")]
-    public async Task<IActionResult> AddImageOcopProduct([FromForm] AddImageRequest addImageRequest)
+    public async Task<IActionResult> AddImageOcopProduct([FromForm] TraVinhMaps.Application.Features.Destination.Models.AddImageRequest addImageRequest)
     {
         if (addImageRequest.imageFile == null && !addImageRequest.imageFile.Any())
         {
@@ -199,6 +200,11 @@ public class OcopProductController : ControllerBase
     public async Task<IActionResult> DeleteImageOcopProduct(string id, string imageUrl)
     {
         var decodedImageUrl = Uri.UnescapeDataString(imageUrl);
+        var isDeleteUrl = await this._imageManagementOcopProductServices.DeleteImageOCOP(decodedImageUrl);
+        if (!isDeleteUrl)
+        {
+            return this.ApiError("No valid images url were removed.");
+        }
         var ocopProduct = await _service.GetByIdAsync(id);
         if (ocopProduct == null)
         {

--- a/src/TraVinhMaps.Application/Features/OcopProduct/ImageManagementOcopProductServices.cs
+++ b/src/TraVinhMaps.Application/Features/OcopProduct/ImageManagementOcopProductServices.cs
@@ -29,4 +29,24 @@ public class ImageManagementOcopProductServices
         }
         return images;
     }
+
+    public async Task<bool> DeleteImageOCOP(string imageUrl)
+    {
+        if (string.IsNullOrEmpty(imageUrl))
+            return false;
+
+        try
+        {
+            var uri = new Uri(imageUrl);
+            var fileName = uri.Segments.Last();
+            var publicId = System.IO.Path.GetFileNameWithoutExtension(fileName);
+
+            var result = await _cloudinaryService.DeleteImageAsync(publicId);
+            return result.Result == "ok";
+        }
+        catch (Exception ex)
+        {
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Introduced DeleteImageOCOP method in ImageManagementOcopProductServices to handle image deletion via Cloudinary. Updated OcopProductController to use this method and return an error if no valid image URLs are removed.