### PR TITLE
Update duplicate checks and error messages in controllers

### DIFF
--- a/src/TraVinhMaps.Api/Controllers/CompanyController.cs
+++ b/src/TraVinhMaps.Api/Controllers/CompanyController.cs
@@ -49,9 +49,9 @@ public class CompanyController : ControllerBase
     public async Task<IActionResult> AddCompany([FromBody] CreateCompanyRequest createCompanyRequest)
     {
         var allCompany = await _companyService.ListAllAsync();
-        if (allCompany != null && allCompany.Any(c => c.Name == createCompanyRequest.Name))
+        if (allCompany != null && allCompany.Any(c => c.Name == createCompanyRequest.Name && c.Address == createCompanyRequest.Address))
         {
-            return this.ApiError("Company already exists.");
+            return this.ApiError("Company name already exists.");
         }
         var createCompany = CompanyMapper.Mapper.Map<Company>(createCompanyRequest);
         var company = await _companyService.AddAsync(createCompany);
@@ -67,9 +67,9 @@ public class CompanyController : ControllerBase
             throw new NotFoundException("Company not found.");
         }
         var allCompany = await _companyService.ListAllAsync();
-        if (allCompany != null && allCompany.Any(c => c.Name == updateCompanyRequest.Name && c.Id != updateCompanyRequest.Id))
+        if (allCompany != null && allCompany.Any(c => c.Name == updateCompanyRequest.Name && c.Address == updateCompanyRequest.Address && c.Id != updateCompanyRequest.Id))
         {
-            return this.ApiError("Company already exists.");
+            return this.ApiError("Company name already exists.");
         }
 
         existingCompany.Name = updateCompanyRequest.Name;

--- a/src/TraVinhMaps.Api/Controllers/OcopTypeController.cs
+++ b/src/TraVinhMaps.Api/Controllers/OcopTypeController.cs
@@ -48,7 +48,7 @@ public class OcopTypeController : ControllerBase
         var allOcopTypes = await _typeService.ListAllAsync();
         if (allOcopTypes != null && allOcopTypes.Any(ot => ot.OcopTypeName == createOcopTypeRequest.OcopTypeName))
         {
-            return this.ApiError("Ocop type already exists.");
+            return this.ApiError("Ocop type name already exists.");
         }
         var createOcopType = OcopTypeMapper.Mapper.Map<OcopType>(createOcopTypeRequest);
         createOcopType.OcopTypeStatus = true;
@@ -67,7 +67,7 @@ public class OcopTypeController : ControllerBase
         var allOcopTypes = await _typeService.ListAllAsync();
         if (allOcopTypes != null && allOcopTypes.Any(ot => ot.OcopTypeName == updateOcopTypeRequest.OcopTypeName && ot.Id != updateOcopTypeRequest.Id))
         {
-            return this.ApiError("Ocop type already exists.");
+            return this.ApiError("Ocop type name already exists.");
         }
         existingOcopType.OcopTypeName = updateOcopTypeRequest.OcopTypeName;
 


### PR DESCRIPTION
Refined duplicate company checks to include address in CompanyController and updated error messages to specify 'name already exists'. Similarly, updated error messages in OcopTypeController to specify 'Ocop type name already exists' for clarity.